### PR TITLE
feat: add automation detection avoidance via launch arg

### DIFF
--- a/__tests__/launch-args.test.ts
+++ b/__tests__/launch-args.test.ts
@@ -22,6 +22,7 @@ describe("Launch Args Merging", () => {
       expect(args).toContain("--allow-insecure-localhost");
       expect(args).toContain("--allow-http-screen-capture");
       expect(args).toContain("--no-zygote");
+      expect(args).toContain("--disable-blink-features=AutomationControlled");
     });
   });
 

--- a/src/puppeteer.constants.ts
+++ b/src/puppeteer.constants.ts
@@ -9,6 +9,7 @@ const args: string[] = [
   "--allow-insecure-localhost", // Enables TLS/SSL errors on localhost to be ignored (no interstitial, no blocking of requests).
   "--allow-http-screen-capture", // Allow non-secure origins to use the screen capture API and the desktopCapture extension API.
   "--no-zygote", // https://codereview.chromium.org/2384163002
+  "--disable-blink-features=AutomationControlled", // Removes navigator.webdriver flag that indicates automation
 ];
 // add --no-sandbox when running on Linux, required with --no-zygote
 if (typeof process.getuid === "function") {


### PR DESCRIPTION
## Summary

- Add `--disable-blink-features=AutomationControlled` to default Chrome launch arguments, removing the `navigator.webdriver` flag that indicates browser automation
- Document that `puppeteer-extra-plugin-stealth` is mostly obsolete with Chrome's new headless mode (112+)
- Add optional WebGL vendor spoofing example for users who need additional evasions

## Background

Chrome 112+ introduced a new headless mode that is essentially a full browser without a window. This change made most stealth evasions from `puppeteer-extra-plugin-stealth` obsolete:

| Detection Vector | Status in New Headless |
|------------------|------------------------|
| User-Agent contains "HeadlessChrome" | ✅ Fixed |
| `window.chrome.*` APIs | ✅ Present |
| `navigator.plugins` | ✅ Populated |
| `navigator.webdriver` | ⚠️ Still true (fixed by this PR) |

## Test plan

- [x] Verify `--disable-blink-features=AutomationControlled` is in default args
- [x] Existing launch args tests pass
- [x] Documentation updated with automation detection section

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added detailed automation detection section covering detection vectors and mitigation strategies
  * Included examples for injecting custom browser evasion scripts
  * Updated guidance on headless Chrome configuration and default launch options

* **New Defaults**
  * Added a new Chrome launch argument to the default configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->